### PR TITLE
Update expertise copy for Australian mobile business

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                 <div class="expertise-content">
                     <div>
                         <h2 id="expertise-title">Hands-on expertise from ground to canopy</h2>
-                        <p>Koby has spent over a decade working in the Pacific Northwest and beyond, studying arboriculture, soils, and forest ecology. Whether you're caring for a cherished heritage oak or navigating complex site constraints, you'll receive advice you can trust.</p>
+                        <p>Koby has spent over a decade caring for trees across Australia, studying arboriculture, soils, and forest ecology while journeying with his family. Whether you're tending to a cherished heritage gum or navigating complex site constraints, you'll receive advice you can trust.</p>
                         <ul class="expertise-list">
                             <li>Resilient pruning strategies that respect species-specific growth habits.</li>
                             <li>Consultations that translate technical findings into clear next steps.</li>
@@ -128,7 +128,7 @@
                     </div>
                     <div class="highlight-card">
                         <h3>Service Area</h3>
-                        <p>Based in Portland, Oregon and available for regional consulting throughout the Willamette Valley, Columbia Gorge, and coastal communities.</p>
+                        <p>Headquartered in South Australia and coordinating projects nationwide while traveling with the family through diverse Australian landscapes.</p>
                         <a class="highlight-link" href="#contact">Ask about your project</a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- refresh the expertise biography to highlight travel-based Australian operations
- update the service area highlight card to note the South Australia headquarters and nationwide availability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3d762120c832ab975a05d96f1706c